### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,9 +49,7 @@ To allow interoperability among commands and tools, all of them share a common J
 data format. In other words, APICheck commands output JSON documents, and accept them
 as input, too. This allows you to build pipelines (as we showed in the previous section).
 
-<div style="text-align: center;">
-  <img width="300px" src="{{ "/assets/images/data_format.png" | relative_url }}" alt="APICheck data format">
-</div>
+![Data formats](/assets/images/data_format.png)
 
 ## Contribution
 


### PR DESCRIPTION
Fix broken image URL. Not sure why we're getting the embedded HTML instead of clean markdown. Maybe a bug in the tooling used to generate the doc?